### PR TITLE
changed keybind behaviour

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,7 @@ alt.once('playerConnect', async (player: alt.Player) => {
 });
 
 async function showView(player: alt.Player) {
-    keyBinding.on(adminpanelEvents.bindings.F4, () => {
+    keyBinding.on(adminpanelEvents.bindings.F4, (player) => {
         adminpanelShow(player);
     });
 }


### PR DESCRIPTION
We had some issues where for e.x a _2nd player_ would press the keybind and on the _first player_ the menu would **open** aswell.

- included player on keybind

Should be fixed now, edited at:
> 05/04/2025 by thirst aka programmernb-ctrl