### PR TITLE
changed keybind behaviour server/index.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,7 @@ alt.once('playerConnect', async (player: alt.Player) => {
 });
 
 async function showView(player: alt.Player) {
-    keyBinding.on(adminpanelEvents.bindings.F4, () => {
+    keyBinding.on(adminpanelEvents.bindings.F4, (player) => {
         adminpanelShow(player);
     });
 }


### PR DESCRIPTION
### _Changes_
- included player in keyBinding.on

We had a issue with the gui opening for the first player too if the second player presses the keybind.
This pull request should fix this

edited at:
> 05.04.2025 by thirst aka programmernb-ctrl